### PR TITLE
Updating terragrunt flags since they have changed with the most recent version

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -46,16 +46,16 @@ jobs:
 
       - name: Apply ecr
         working-directory: terragrunt/env/staging/ecr
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+        run: terragrunt apply --non-interactive -auto-approve
 
       - name: Apply route53
         working-directory: terragrunt/env/staging/route53
-        run: terragrunt apply ---non-interactive -auto-approve
+        run: terragrunt apply --non-interactive -auto-approve
 
       - name: Apply vpc
         working-directory: terragrunt/env/staging/vpc
-        run: terragrunt apply ---non-interactive -auto-approve
+        run: terragrunt apply --non-interactive -auto-approve
 
       - name: Apply alb
         working-directory: terragrunt/env/staging/alb
-        run: terragrunt apply ---non-interactive -auto-approve
+        run: terragrunt apply --non-interactive -auto-approve


### PR DESCRIPTION
The terragrunt flags have changed with the newest version of terragrunt where the flags are now just `--non-interactive` as opposed to` --terragrunt-non-interactive`. 

For reference:
https://terragrunt.gruntwork.io/docs/reference/cli/global-flags/#non-interactive