### PR TITLE
Fix ECR terragrunt file

### DIFF
--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -85,7 +85,7 @@ resource "aws_security_group_rule" "ecs_tasks_egress_rds" {
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
-  source_security_group_id = var.rds_security_group_id
+  source_security_group_id = var.proxy_security_group_id
   description              = "Allow outbound traffic to RDS PostgreSQL"
   security_group_id        = aws_security_group.ecs_tasks.id
 }

--- a/terragrunt/aws/ecs/variables.tf
+++ b/terragrunt/aws/ecs/variables.tf
@@ -64,7 +64,7 @@ variable "alb_security_group_id" {
   type        = string
 }
 
-variable "rds_security_group_id" {
+variable "proxy_security_group_id" {
   description = "Security group ID of the RDS database"
   type        = string
 }

--- a/terragrunt/aws/rds/outputs.tf
+++ b/terragrunt/aws/rds/outputs.tf
@@ -1,8 +1,3 @@
-output "database_proxy_security_group_id" {
-  description = "The security group id of the rds cluster"
-  value       = module.blawx_rds_cluster.proxy_security_group_id
-}
-
 output "rds_cluster_id" {
   description = "The id of the rds cluster"
   value       = module.blawx_rds_cluster.rds_cluster_id
@@ -12,8 +7,6 @@ output "proxy_security_group_id" {
   description = "The id of the DB proxy security group"
   value       = module.blawx_rds_cluster.proxy_security_group_id
 }
-
-# Additional RDS Cluster Outputs
 output "rds_cluster_endpoint" {
   description = "RDS cluster endpoint"
   value       = module.blawx_rds_cluster.rds_cluster_endpoint

--- a/terragrunt/env/staging/ecs/terragrunt.hcl
+++ b/terragrunt/env/staging/ecs/terragrunt.hcl
@@ -58,7 +58,7 @@ dependency "rds" {
   mock_outputs = {
     rds_cluster_endpoint     = "blawx-staging-database.cluster-abc123.ca-central-1.rds.amazonaws.com"
     rds_cluster_id           = "blawx-staging-database"
-    proxy_security_group_id    = "sg-rds123456789"
+    proxy_security_group_id  = "sg-rds123456789"
   }
 }
 
@@ -151,7 +151,7 @@ inputs = {
   vpc_id                 = dependency.vpc.outputs.vpc_id
   private_subnet_ids     = dependency.vpc.outputs.private_subnet_ids
   alb_security_group_id  = dependency.alb.outputs.alb_security_group_id
-  rds_security_group_id  = dependency.rds.outputs.rds_security_group_id
+  proxy_security_group_id  = dependency.rds.outputs.proxy_security_group_id
   
   # Load balancer integration
   lb_target_group_arn = dependency.alb.outputs.target_group_arn

--- a/terragrunt/env/staging/ecs/terragrunt.hcl
+++ b/terragrunt/env/staging/ecs/terragrunt.hcl
@@ -57,10 +57,8 @@ dependency "rds" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     rds_cluster_endpoint     = "blawx-staging-database.cluster-abc123.ca-central-1.rds.amazonaws.com"
-    rds_cluster_port         = "5432"
-    rds_cluster_database_name = "blawx_staging"
-    rds_cluster_master_username = "blawx_admin"
-    rds_security_group_id    = "sg-rds123456789"
+    rds_cluster_id           = "blawx-staging-database"
+    proxy_security_group_id    = "sg-rds123456789"
   }
 }
 
@@ -99,7 +97,7 @@ inputs = {
   desired_count = 1
   
   # Container configuration
-  ecr_repository_url = dependency.ecr.outputs.repository_url
+  ecr_repository_url = dependency.ecr.outputs.ecr_repository_url
   container_port     = 8000
   
   # Container environment variables
@@ -114,19 +112,11 @@ inputs = {
     },
     {
       name  = "DATABASE_HOST"
-      value = dependency.rds.outputs.rds_cluster_endpoint
+      value = .rds.outputs.rds_cluster_endpoint
     },
     {
       name  = "DATABASE_PORT"
-      value = tostring(dependency.rds.outputs.rds_cluster_port)
-    },
-    {
-      name  = "DATABASE_NAME"
-      value = dependency.rds.outputs.rds_cluster_database_name
-    },
-    {
-      name  = "DATABASE_USER"
-      value = dependency.rds.outputs.rds_cluster_master_username
+      value = "5432" 
     },
     {
       name  = "DEBUG"
@@ -145,9 +135,17 @@ inputs = {
   # Container secrets (from SSM Parameter Store)
   container_secrets = [
     {
+      name     = "DATABASE_USER"
+      valueFrom = dependency.ssm.outputs.parameter_arns.database_username
+    },
+    {
       name      = "DATABASE_PASSWORD"
       valueFrom = dependency.ssm.outputs.parameter_arns.database_password
     },
+    {
+      name      = "DATABASE_NAME"
+      valueFrom = dependency.ssm.outputs.parameter_arns.database_name
+    }
     {
       name      = "DJANGO_SECRET_KEY"
       valueFrom = dependency.ssm.outputs.parameter_arns.django_secret_key

--- a/terragrunt/env/staging/ecs/terragrunt.hcl
+++ b/terragrunt/env/staging/ecs/terragrunt.hcl
@@ -46,7 +46,7 @@ dependency "ecr" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    repository_url = "123456789.dkr.ecr.ca-central-1.amazonaws.com/blawx-staging"
+    ecr_repository_url = "123456789.dkr.ecr.ca-central-1.amazonaws.com/blawx-staging"
   }
 }
 
@@ -86,11 +86,6 @@ dependency "ssm" {
 }
 
 inputs = {
-  # Environment configuration
-  product_name      = local.env_vars.inputs.product_name
-  env              = local.env_vars.inputs.env
-  billing_tag_value = "blawx-${local.env_vars.inputs.env}"
-  
   # Task configuration
   task_cpu      = 512
   task_memory   = 1024
@@ -112,7 +107,7 @@ inputs = {
     },
     {
       name  = "DATABASE_HOST"
-      value = .rds.outputs.rds_cluster_endpoint
+      value = dependency.rds.outputs.rds_cluster_endpoint
     },
     {
       name  = "DATABASE_PORT"

--- a/terragrunt/env/staging/ecs/terragrunt.hcl
+++ b/terragrunt/env/staging/ecs/terragrunt.hcl
@@ -140,7 +140,7 @@ inputs = {
     {
       name      = "DATABASE_NAME"
       valueFrom = dependency.ssm.outputs.parameter_arns.database_name
-    }
+    },
     {
       name      = "DJANGO_SECRET_KEY"
       valueFrom = dependency.ssm.outputs.parameter_arns.django_secret_key


### PR DESCRIPTION
# Summary | Résumé

Fixing ECS terragrunt.hcl file as some names were called wrong names plus some output variables were non existant. 