### PR TITLE
Changing runs on to be ubuntu arm 64 runner

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -52,10 +52,10 @@ jobs:
 
       - name: Build and tag Docker image
         run: |
-          # Build the Docker image for AMD64 (GitHub Actions runners)
+          # Build the Docker image for ARM64
           docker build \
             -t $REGISTRY:${{ env.IMAGE_TAG_LATEST }} \
-            --platform linux/amd64 \
+            --platform linux/arm64 \
             -f Dockerfile.production \
             .
 


### PR DESCRIPTION
# Summary | Résumé

Configuring the Github action runner to use ARM64 architecture Ubuntu version. 