### PR TITLE
fix: disable debug and remove hardcoded secret

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -18,6 +18,7 @@ env:
   TF_VAR_database_password: ${{ secrets.POSTGRES_PASSWORD }}
   TF_VAR_database_username: ${{ secrets.POSTGRES_USER }}
   TF_VAR_database_name: ${{ secrets.POSTGRES_DB }}
+  TF_VAR_django_secret_key: ${{ secrets.DJANGO_SECRET_KEY }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -16,6 +16,7 @@ env:
   TF_VAR_database_password: ${{ secrets.POSTGRES_PASSWORD }}
   TF_VAR_database_username: ${{ secrets.POSTGRES_USER }}
   TF_VAR_database_name: ${{ secrets.POSTGRES_DB }}
+  TF_VAR_django_secret_key: ${{ secrets.DJANGO_SECRET_KEY }}
 
 permissions:
   id-token: write

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,0 +1,3 @@
+FROM lexpedite/blawx:latest@sha256:d217a1578ef6902f7421d50b520324ca42a94af765e1dade9407d3c847d1d96f
+
+COPY ./blawx/settings.py /app/blawx/blawx/settings.py

--- a/blawx/settings.py
+++ b/blawx/settings.py
@@ -10,10 +10,12 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
+import os
+
 from pathlib import Path
 
 # For adding a version identifier
-BLAWX_VERSION = "v1.6.22-alpha"
+BLAWX_VERSION = "v1.6.21-alpha"
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -23,11 +25,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-15(10(&q#urg%$02!37b^i^(r#p207e*3hrcjn=$k4_or&vha5"
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+DEBUG = False
 
 ALLOWED_HOSTS = ["*"]
 
@@ -124,7 +123,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "MST"
 
 USE_I18N = True
 
@@ -135,10 +134,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = "static/"
-
-STATIC_ROOT = BASE_DIR / "staticfiles"  # Define the root directory for static files
-
-STATICFILES_DIRS = [BASE_DIR / "static"]  # Define the directory for static files
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -94,7 +94,7 @@ module "ecs" {
 
 
   # Container Configuration
-  container_image            = "lexpedite/blawx:latest"
+  container_image            = "${var.ecr_repository_url}:latest"
   container_port             = var.container_port
   container_host_port        = var.container_port
   container_name             = "${var.product_name}-container"

--- a/terragrunt/env/staging/ssm/terragrunt.hcl
+++ b/terragrunt/env/staging/ssm/terragrunt.hcl
@@ -16,9 +16,6 @@ inputs = {
   database_username = "blawx_admin"  # Should match RDS configuration
   database_name     = "blawx_${local.env_vars.inputs.env}"  # Should match RDS database_name
 
-  # Django configuration
-  django_secret_key     = "CHANGE_ME_IN_PRODUCTION_USE_ENV_VAR"  # Set via: export TF_VAR_django_secret_key="your-django-secret"
-
   # Additional environment-specific parameters
   additional_parameters = {
     "cache-timeout" = {


### PR DESCRIPTION
# Summary
Update the Blawx config to remove debug information and no longer use a hardcoded django secret.
